### PR TITLE
feat(issue-7): se refactoriza logica para la creacion de una orden y consumo de servicios

### DIFF
--- a/src/main/java/com/infragest/infra_orders_service/excepcion/DeviceUnavailableException.java
+++ b/src/main/java/com/infragest/infra_orders_service/excepcion/DeviceUnavailableException.java
@@ -8,7 +8,9 @@ public class DeviceUnavailableException extends RuntimeException {
     public enum Type {
     NOT_FOUND,
     BAD_REQUEST,
-    CONFLICT, INTERNAL_SERVER
+    CONFLICT,
+    INTERNAL_SERVER,
+    SERVICE_UNAVAILABLE
     }
 
     /**

--- a/src/main/java/com/infragest/infra_orders_service/service/OrderService.java
+++ b/src/main/java/com/infragest/infra_orders_service/service/OrderService.java
@@ -6,7 +6,6 @@ import com.infragest.infra_orders_service.model.OrderRq;
 import com.infragest.infra_orders_service.model.OrderRs;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 /**

--- a/src/main/java/com/infragest/infra_orders_service/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/infragest/infra_orders_service/service/impl/OrderServiceImpl.java
@@ -70,7 +70,16 @@ public class OrderServiceImpl implements OrderService {
      */
     private final RabbitTemplate rabbitTemplate;
 
-
+    /**
+     * Constructor con los parametros iniciales.
+     *
+     * @param orderRepository
+     * @param orderItemRepository
+     * @param devicesClient
+     * @param groupClient
+     * @param employeeClient
+     * @param rabbitTemplate
+     */
     public OrderServiceImpl(
             OrderRepository orderRepository,
             OrderItemRepository orderItemRepository,
@@ -88,6 +97,16 @@ public class OrderServiceImpl implements OrderService {
         this.rabbitTemplate = rabbitTemplate;
     }
 
+    /**
+     * Crea una nueva orden a partir de la solicitud proporcionada.
+     *
+     * @param rq Objeto de solicitud que contiene la información necesaria para crear la orden.
+     *           Incluye dispositivos, tipos de asignación (`assigneeType`), e identificadores de asignación (`assigneeId`).
+     * @return DTO que representa la orden creada.
+     * @throws OrderException Si ocurre un error durante la verificación de dispositivos, la validación de destinatarios o la creación de la orden.
+     * @since 2026-01-28
+     * @author Bunnystring
+     */
     @Override
     @Transactional
     public OrderRs createOrder(OrderRq rq) {

--- a/src/main/java/com/infragest/infra_orders_service/util/MessageException.java
+++ b/src/main/java/com/infragest/infra_orders_service/util/MessageException.java
@@ -10,39 +10,41 @@ public abstract class MessageException {
 
     private MessageException() {}
 
-    // Ordenes
-    public static final String ORDER_NOT_FOUND = "Orden no encontrada: %s";
-    public static final String ORDER_CREATE_FAILED = "No se pudo crear la orden: %s";
-    public static final String ORDER_STATE_TRANSITION_INVALID = "Transición de estado inválida para la orden %s: %s";
-    public static final String ORDER_ALREADY_FINALIZED = "La orden %s ya está finalizada";
+    // Orders
+    public static final String SERVICE_UNAVAILABLE = "The service is currently unavailable.";
+    public static final String ORDER_NOT_FOUND = "Order not found: %s";
+    public static final String ORDER_CREATE_FAILED = "Failed to create the order: %s";
+    public static final String ORDER_STATE_TRANSITION_INVALID = "Invalid state transition for order %s: %s";
+    public static final String ORDER_ALREADY_FINALIZED = "Order %s is already finalized";
 
-    // Equipos / Devices
-    public static final String EQUIPMENT_NOT_FOUND = "Equipo no encontrado: %s";
-    public static final String EQUIPMENT_NOT_AVAILABLE = "Los siguientes equipos no están disponibles: %s";
-    public static final String EQUIPMENT_RESERVE_FAILED = "No se pudieron reservar los equipos: %s";
-    public static final String EQUIPMENT_RESTORE_FAILED = "No se pudieron restaurar los estados de los equipos: %s";
-    public static final String INVALID_EQUIPMENT_LIST = "Lista de equipos inválida";
+    // Devices / Equipment
+    public static final String DEVICE_ERROR_COMMUNICATION = "Error communicating with the devices service.";
+    public static final String EQUIPMENT_NOT_FOUND = "Equipment not found: %s";
+    public static final String EQUIPMENT_NOT_AVAILABLE = "The following equipment is not available: %s";
+    public static final String EQUIPMENT_RESERVE_FAILED = "Failed to reserve the equipment: %s";
+    public static final String EQUIPMENT_RESTORE_FAILED = "Failed to restore the state of the equipment: %s";
+    public static final String INVALID_EQUIPMENT_LIST = "Invalid equipment list";
+    public static final String DEVICE_NOT_FOUND_BY_IDS = "";
 
     // Assignee (employee / group)
-    public static final String ASSIGNEE_REQUIRED = "El assignee (tipo e id) es requerido";
-    public static final String ASSIGNEE_NOT_FOUND = "Assignee no encontrado: %s";
-    public static final String ASSIGNEE_INVALID = "Assignee inválido o en estado no permitido: %s";
-    public static final String GROUP_NO_MEMBERS = "El grupo %s no tiene miembros con email";
-    public static final String EMPLOYEE_NOT_ACTIVE = "El empleado %s no está activo";
-    public static final String EMPLOYEE_NO_EMAIL = "El empleado %s no tiene email registrado";
-    public static final String GROUP_NOT_FOUND = "El grupo %s no fue encontrado.";
-    public static final String EMPLOYEE_INACTIVE = "El empleado %s no está activo.";
-    public static final String EMPLOYEE_NOT_FOUND = "El empleado %s no fue encontrado.";
+    public static final String ASSIGNEE_REQUIRED = "The assignee (type and ID) is required";
+    public static final String ASSIGNEE_NOT_FOUND = "Assignee not found: %s";
+    public static final String ASSIGNEE_INVALID = "Invalid or disallowed assignee status: %s";
+    public static final String GROUP_NO_MEMBERS = "Group %s has no members with valid emails";
+    public static final String EMPLOYEE_NOT_ACTIVE = "Employee %s is not active";
+    public static final String EMPLOYEE_NO_EMAIL = "Employee %s has no registered email";
+    public static final String GROUP_NOT_FOUND = "Group %s was not found.";
+    public static final String EMPLOYEE_INACTIVE = "Employee %s is not active.";
+    public static final String EMPLOYEE_NOT_FOUND = "Employee %s was not found.";
 
     // Request / validation / UUID
-    public static final String INVALID_REQUEST = "Request inválido";
-    public static final String INVALID_UUID = "Identificador inválido: %s";
-    public static final String MISSING_PARAMETER = "Falta el parámetro requerido: %s";
+    public static final String INVALID_REQUEST = "Invalid request";
+    public static final String INVALID_UUID = "Invalid identifier: %s";
+    public static final String MISSING_PARAMETER = "Missing required parameter: %s";
 
-    // Operación / permisos / DB / interno
-    public static final String OPERATION_NOT_ALLOWED = "Operación no permitida: %s";
-    public static final String DATABASE_ERROR = "Error en la base de datos";
-    public static final String INTERNAL_ERROR = "Error interno del servidor";
-    public static final String DEPENDENCY_ERROR = "Error al comunicarse con un servicio dependiente.";
-
+    // Operation / permissions / DB / internal
+    public static final String OPERATION_NOT_ALLOWED = "Operation not allowed: %s";
+    public static final String DATABASE_ERROR = "Database error";
+    public static final String INTERNAL_ERROR = "Internal server error";
+    public static final String DEPENDENCY_ERROR = "Error communicating with a dependent service.";
 }


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción
Este PR incluye varias mejoras y refactorizaciones importantes relacionadas con la creación de órdenes, estandarización de errores y manejo lógico cuando un servicio consumido no está disponible:

- **Nuevo Tipo de Error HTTP:**  
  - Se agrega el manejo del tipo de error `SERVICE_UNAVAILABLE` para responder apropiadamente cuando un microservicio requerido está fuera de servicio.
  - Se configura de manera lógica la propagación del error para manejar eficientemente los fallos provenientes de servicios como los microservicios de dispositivos o grupos.

- **Refactor en el Flujo de Creación de Órdenes:**
  - Ahora, el flujo de creación de órdenes incluye los siguientes pasos:
    1. Se crea la orden en la base de datos.
    2. Posteriormente, se reserva cada dispositivo de manera transaccional *usando el ID de la orden como referencia*.
  - **Razonamiento:** Esto asegura que el microservicio de dispositivos tenga conocimiento del ID de orden correspondiente, eliminando posibles inconsistencias o problemas de relación.

- **Estandarización de Mensajes de Error:**
  - Los errores generados ahora son claros y cumplen con el estándar establecido.
  - Se introducen constantes centralizadas en `MessageException` para reducir la duplicación y mejorar la legibilidad.

- **Errores de Servicios no Disponibles:**
  - Se agrega y configura el manejo del escenario en el que un microservicio consumido (p. ej., el microservicio de dispositivos) no esté disponible, asegurando una respuesta consistente hacia el cliente.
  
## ¿Qué tipo de cambio es?
- [x] Bugfix 🐞
- [x] Feature ✨
- [x] Refactor 🔧
- [x] Documentación 📚
- [x] Otro

## ¿Cómo probar estos cambios?

**Prueba el Flujo de Creación de Órdenes:**
   - Realiza una solicitud para crear una nueva orden que incluya múltiples dispositivos.
   - Verifica que:
     - La orden se crea correctamente en la base de datos.
     - Los dispositivos se reservan correctamente usando el ID de la orden generada.

   **Ejemplo de Prueba Manual:**
   - Test con dispositivos correctos (normal).
   - Test con dispositivos duplicados o inexistentes.
   - Test cuando el microservicio de dispositivos no responde (`SERVICE_UNAVAILABLE`).
   - Test cuando el microservicio de grupos no responde (`SERVICE_UNAVAILABLE`).

**Pruebas de Error de Microservicio:**
   - Configura el microservicio de dispositivos para simular interrupciones o caídas.
   - - Configura el microservicio de grupos  para simular interrupciones o caídas.
   - Asegúrate de que se devuelva el error correspondiente (`SERVICE_UNAVAILABLE`) y que el mensaje sea claro para el cliente.

**Logs y Mensajes de Error:**
   - Verifica los logs generados para garantizar que los errores sean descriptivos y los mensajes correctos sean devueltos al cliente.

**Simulaciones de Servicios Concurrentes:**
   - Simula múltiples solicitudes simultáneas de creación de órdenes para garantizar la integridad transaccional y evitar errores de concurrencia.

## Checklist
- [x] El código compila y pasa los tests
- [x] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
<!-- Adjunta capturas si hay cambios visuales. -->

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
- Presta especial atención al flujo refactorizado de creación de órdenes y asegurarte de que cumple con las expectativas.
- Puedes revisar cómo se integran los errores transaccionales y las implementaciones relacionadas con el tipo de error `SERVICE_UNAVAILABLE`.