### PR TITLE
Merge main to dev

### DIFF
--- a/src/main/java/com/infragest/infra_orders_service/client/DevicesClient.java
+++ b/src/main/java/com/infragest/infra_orders_service/client/DevicesClient.java
@@ -4,6 +4,7 @@ import com.infragest.infra_orders_service.config.FeignClientConfig;
 import com.infragest.infra_orders_service.model.ApiResponseDto;
 import com.infragest.infra_orders_service.model.DeviceRs;
 import com.infragest.infra_orders_service.model.DevicesBatchRq;
+import com.infragest.infra_orders_service.model.RestoreDevicesRq;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -42,8 +43,9 @@ public interface DevicesClient {
     /**
      * Restaura los estados originales de devices (usado al finalizar una orden).
      *
-     * @return mapa con "success" y opcional "message"
+     * @param restoreDevicesRq solicitud con los dispositivos y estados originales
+     * @return respuesta con el estado de la operación
      */
     @PostMapping("/api/devices/restore")
-    Map<String, Object> restoreDeviceStates(@RequestBody Map<String, Object> body);
+    Map<String, Object> restoreDeviceStates(@RequestBody RestoreDevicesRq restoreDevicesRq);
 }

--- a/src/main/java/com/infragest/infra_orders_service/controller/OrderController.java
+++ b/src/main/java/com/infragest/infra_orders_service/controller/OrderController.java
@@ -1,5 +1,6 @@
 package com.infragest.infra_orders_service.controller;
 
+import com.infragest.infra_orders_service.enums.OrderState;
 import com.infragest.infra_orders_service.model.OrderRq;
 import com.infragest.infra_orders_service.model.OrderRs;
 import com.infragest.infra_orders_service.service.OrderService;
@@ -113,5 +114,31 @@ public class OrderController {
     @GetMapping("/{id}")
     public ResponseEntity<OrderRs> getOrderById(@PathVariable UUID id) {
         return ResponseEntity.ok(orderService.getOrder(id));
+    }
+
+    /**
+     * Cambiar el estado de una orden.
+     *
+     * Este endpoint permite actualizar el estado de una orden existente. Valida
+     * que el nuevo estado sea válido y coherente según las reglas del negocio.
+     *
+     * @param orderId UUID único de la orden a actualizar.
+     * @param newState Nuevo estado a asignar a la orden.
+     * @return Una respuesta con el código HTTP 200 (OK) si el estado se actualiza correctamente.
+     */
+    @Operation(summary = "Cambiar estado de una orden", description = "Permite actualizar el estado de una orden existente.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Estado de la orden actualizado con éxito"),
+            @ApiResponse(responseCode = "400", description = "Nuevo estado inválido o transición no permitida"),
+            @ApiResponse(responseCode = "404", description = "La orden no fue encontrada"),
+            @ApiResponse(responseCode = "500", description = "Error interno del servidor")
+    })
+    @PutMapping("/{orderId}/state")
+    public ResponseEntity<Void> updateOrderState(
+            @PathVariable UUID orderId,
+            @RequestParam OrderState newState
+    ) {
+        orderService.changeState(orderId, newState);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/infragest/infra_orders_service/excepcion/OrderException.java
+++ b/src/main/java/com/infragest/infra_orders_service/excepcion/OrderException.java
@@ -16,7 +16,8 @@ public class OrderException extends RuntimeException {
     public enum Type {
         NOT_FOUND,
         BAD_REQUEST,
-        CONFLICT, INTERNAL_SERVER
+        CONFLICT,
+        INTERNAL_SERVER
     }
 
     /**

--- a/src/main/java/com/infragest/infra_orders_service/model/RestoreDevicesRq.java
+++ b/src/main/java/com/infragest/infra_orders_service/model/RestoreDevicesRq.java
@@ -1,0 +1,55 @@
+package com.infragest.infra_orders_service.model;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * DTO para realizar la solicitud de restauración de estados originales de los dispositivos.
+ *
+ * {@code items} contiene una lista de {@link RestoreItem}, cada uno representando un dispositivo a restaurar
+ * con su estado original.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RestoreDevicesRq {
+
+    /**
+     * Lista de dispositivos junto con sus estados originales que deben ser restaurados.
+     */
+    @NotEmpty(message = "La lista de items no puede estar vacía")
+    @Valid
+    private List<RestoreItem> items;
+
+    /**
+     * Sub-clase interna que representa cada dispositivo y su estado original.
+     */
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RestoreItem {
+
+        /**
+         * Identificador único del dispositivo.
+         */
+        @NotNull(message = "deviceId es requerido")
+        private UUID deviceId;
+
+        /**
+         * Estado al que debe restaurarse el dispositivo (por ejemplo: GOOD_CONDITION, REGULAR).
+         */
+        @NotNull(message = "state es requerido")
+        private DeviceStatusEnum state;
+    }
+
+}

--- a/src/main/java/com/infragest/infra_orders_service/service/OrderService.java
+++ b/src/main/java/com/infragest/infra_orders_service/service/OrderService.java
@@ -52,7 +52,7 @@ public interface OrderService {
      * @return la representación actualizada {@link OrderRs}
      * @throws RuntimeException si la orden no existe o si la transición no es válida
      */
-    OrderRs changeState(UUID orderId, OrderState newState);
+    void changeState(UUID orderId, OrderState newState);
 
     /**
      * Obtiene las órdenes asociadas a un assignee (empleado o grupo).

--- a/src/main/java/com/infragest/infra_orders_service/util/MessageException.java
+++ b/src/main/java/com/infragest/infra_orders_service/util/MessageException.java
@@ -25,6 +25,7 @@ public abstract class MessageException {
     public static final String EQUIPMENT_RESTORE_FAILED = "Failed to restore the state of the equipment: %s";
     public static final String INVALID_EQUIPMENT_LIST = "Invalid equipment list";
     public static final String DEVICE_NOT_FOUND_BY_IDS = "";
+    public static final String DEVICE_RELEASE_FAILED = "Failed to release devices for order %s.";
 
     // Assignee (employee / group)
     public static final String ASSIGNEE_REQUIRED = "The assignee (type and ID) is required";


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción

**Endpoint para cambiar el estado de las órdenes:**
   - Se implementa un endpoint que permite cambiar el estado de una orden.
   - Soporte de transiciones validadas:
     - De `CREATED` a `IN_PROCESS`.
     - De `IN_PROCESS` a `DISPATCHED`.
     - De `DISPATCHED` a `FINISHED`.
   - En el estado `FINISHED`, se restauran los dispositivos a sus estados originales mediante el microservicio `infra-devices-service`.

**Método de Validación de Transiciones de Estado:**
   - Se creó un método para garantizar que las transiciones entre los estados de una orden cumplan con el flujo lógico permitido.
   - Si la transición no es válida, se lanza una excepción `OrderException` con un mensaje descriptivo.

**Integración con `infra-devices-service` mediante FeignClient:**
   - Se agregó un FeignClient para llamar al endpoint `/api/devices/restore` del microservicio `infra-devices-service`.
   - En el estado `FINISHED`, se envía una solicitud con el DTO `RestoreDevicesRq` que contiene los dispositivos y sus estados originales.

**Validación Uniforme con `MessageException`:**
   - Se agregaron mensajes de error centralizados en `MessageException` para asegurar consistencia y estandarización.


## ¿Qué tipo de cambio es?
- [ ] Bugfix 🐞
- [x] Feature ✨
- [] Refactor 🔧
- [x] Documentación 📚
- [x] Otro

## ¿Cómo probar estos cambios?
- Consumir endpoint para Cambiar el Estado de una Orden

## Checklist
- [x] El código compila y pasa los tests
- [x] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
<!-- Adjunta capturas si hay cambios visuales. -->

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
<!-- Información extra útil para quien revisa el PR -->
