### PR TITLE
feat(issue-12): Se implementa servicio que actualiza una orden siguiendo estandar

### DIFF
--- a/src/main/java/com/infragest/infra_orders_service/controller/OrderController.java
+++ b/src/main/java/com/infragest/infra_orders_service/controller/OrderController.java
@@ -141,4 +141,13 @@ public class OrderController {
         orderService.changeState(orderId, newState);
         return ResponseEntity.ok().build();
     }
+
+    @PutMapping("update/{orderId}")
+    public ResponseEntity<Void> updateOrder(
+            @PathVariable UUID orderId,
+            @RequestBody OrderRq orderRq
+    ) {
+        orderService.updateOrder(orderId, orderRq);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/infragest/infra_orders_service/service/OrderService.java
+++ b/src/main/java/com/infragest/infra_orders_service/service/OrderService.java
@@ -76,4 +76,7 @@ public interface OrderService {
      * @param notificationEvent evento que contiene los detalles de la confirmación de notificación.
      */
     void updateOrderNotificationStatus(NotificationEvent notificationEvent);
+
+
+    void updateOrder(UUID orderId, OrderRq orderRq);
 }

--- a/src/main/java/com/infragest/infra_orders_service/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/infragest/infra_orders_service/service/impl/OrderServiceImpl.java
@@ -22,6 +22,7 @@ import com.infragest.infra_orders_service.service.OrderService;
 import com.infragest.infra_orders_service.util.MessageException;
 import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpStatus;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -855,6 +856,33 @@ public class OrderServiceImpl implements OrderService {
                     String.format(MessageException.EQUIPMENT_RESTORE_FAILED, order.getId()),
                     OrderException.Type.INTERNAL_SERVER
             );
+        }
+    }
+
+    public void updateOrder(UUID orderId, OrderRq rq) {
+
+        // Recuperar la orden
+        Order order = orderRepository.findById(orderId).orElseThrow(
+                () -> new OrderException(MessageException.ORDER_NOT_FOUND, OrderException.Type.NOT_FOUND)
+        );
+
+        // Comparar los devicesIds de la orden nueva con la orden antigua y separa los que no coinciden
+        Set<UUID> currentDeviceIds = order.getItems().stream()
+                .map(OrderItem::getDeviceId)
+                .collect(Collectors.toSet());
+
+        Set<UUID> newDeviceIds = new HashSet<>(rq.getDevicesIds());
+
+        // Verificar dispositivos y obtener su estado original
+        Map<UUID, String> originalStates = verifyDevicesAndFetchState((List<UUID>) newDeviceIds);
+
+        // Validar si el tipo de asignación es diferente
+        if (order.getAssigneeType() != rq.getAssigneeType()) {
+            // Obtener los correos asociados a la asignación
+            List<String> recipients = resolveRecipientsAndValidate(rq.getAssigneeType(), rq.getAssigneeId());
+
+            // Publicar el evento
+            publishOrderEvent(savedOrder, recipients);
         }
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción
- Endpoint `PUT /orders/update/{orderId}` para actualizar órdenes existentes
- Gestión inteligente de dispositivos: restaura estados de removidos y reserva nuevos
- Validación de disponibilidad de dispositivos antes de asignar
- Notificación automática cuando cambia el assignee (empleado/grupo)
- Refactorización de `saveOrderAndItems()` para reutilización en creación y actualización
- Método auxiliar `buildRestoreRequest()` para conversión de datos a `RestoreDevicesRq`
- Documentación JavaDoc y OpenAPI/Swagger completa

## ¿Qué tipo de cambio es?
- [x] Bugfix 🐞
- [x] Feature ✨
- [x] Refactor 🔧
- [x] Documentación 📚
- [x] Otro

## ¿Cómo probar estos cambios?

- `POST /orders` → Crear orden con 2 dispositivos
- `PUT /orders/update/{id}` → Cambiar lista de dispositivos (agregar/quitar)
- `PUT /orders/update/{id}` → Cambiar assignee (probar notificación)
- `PUT /orders/update/invalid-id` → Verificar error 404 snapshot guardado
- `PUT /orders/update/{id}` con dispositivo ocupado → Verificar error 409 snapshot guardado


## Checklist
- [x] El código compila y pasa los tests
- [x] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
<!-- Adjunta capturas si hay cambios visuales. -->

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
<!-- Información extra útil para quien revisa el PR -->
