### PR TITLE
Merge main to dev

### DIFF
--- a/src/main/java/com/infragest/infra_orders_service/client/DevicesClient.java
+++ b/src/main/java/com/infragest/infra_orders_service/client/DevicesClient.java
@@ -47,5 +47,5 @@ public interface DevicesClient {
      * @return respuesta con el estado de la operación
      */
     @PostMapping("/api/devices/restore")
-    Map<String, Object> restoreDeviceStates(@RequestBody RestoreDevicesRq restoreDevicesRq);
+    ApiResponseDto<Void>  restoreDeviceStates(@RequestBody RestoreDevicesRq restoreDevicesRq);
 }

--- a/src/main/java/com/infragest/infra_orders_service/controller/OrderController.java
+++ b/src/main/java/com/infragest/infra_orders_service/controller/OrderController.java
@@ -141,4 +141,13 @@ public class OrderController {
         orderService.changeState(orderId, newState);
         return ResponseEntity.ok().build();
     }
+
+    @PutMapping("update/{orderId}")
+    public ResponseEntity<Void> updateOrder(
+            @PathVariable UUID orderId,
+            @RequestBody OrderRq orderRq
+    ) {
+        orderService.updateOrder(orderId, orderRq);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/infragest/infra_orders_service/service/OrderService.java
+++ b/src/main/java/com/infragest/infra_orders_service/service/OrderService.java
@@ -76,4 +76,7 @@ public interface OrderService {
      * @param notificationEvent evento que contiene los detalles de la confirmación de notificación.
      */
     void updateOrderNotificationStatus(NotificationEvent notificationEvent);
+
+
+    void updateOrder(UUID orderId, OrderRq orderRq);
 }

--- a/src/main/java/com/infragest/infra_orders_service/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/infragest/infra_orders_service/service/impl/OrderServiceImpl.java
@@ -721,6 +721,11 @@ public class OrderServiceImpl implements OrderService {
             }
         }
 
+        // Validar y cambiar estado si la orden está completa
+        if(isUpdate) {
+            validateOrderState(order);
+        }
+
         // Guardar la entidad Order (con los items) en la base de datos
         return orderRepository.saveAndFlush(order);
     }
@@ -877,6 +882,9 @@ public class OrderServiceImpl implements OrderService {
      */
     private void releaseOrderDevices(Order order) {
 
+        String errorMsg = null;
+        String errorType = null;
+
         // Construir la lista de items necesarios para el DTO del request
         List<RestoreDevicesRq.RestoreItem> restoreItems = order.getItems().stream()
                 .map(item -> RestoreDevicesRq.RestoreItem.builder()
@@ -894,6 +902,11 @@ public class OrderServiceImpl implements OrderService {
             );
         }
 
+        // Extraer solo los UUIDs para el errorDto
+        List<UUID> devicesIds = restoreItems.stream()
+                .map(RestoreDevicesRq.RestoreItem::getDeviceId)
+                .toList();
+
         // Crear la solicitud DTO para enviar al endpoint de restore
         RestoreDevicesRq restoreDevicesRq = RestoreDevicesRq.builder()
                 .items(restoreItems)
@@ -903,39 +916,45 @@ public class OrderServiceImpl implements OrderService {
 
         try {
             // Llamar al cliente Feign para restaurar los dispositivos
-            Map<String, Object> response = devicesClient.restoreDeviceStates(restoreDevicesRq);
+            ApiResponseDto<Void> response  = devicesClient.restoreDeviceStates(restoreDevicesRq);
 
-            // Validar la respuesta del servicio
-            if (response == null || !Boolean.TRUE.equals(response.get("success"))) {
-                String message = (String) response.getOrDefault("message", "La restauración de dispositivos falló sin detalles.");
-                throw new DeviceUnavailableException(
-                        String.format("Fallo en la restauración de dispositivos para la orden %s: %s", order.getId(), message),
-                        DeviceUnavailableException.Type.INTERNAL_SERVER
-                );
+            // Verifica el éxito de la operación
+            if (!response.isSuccess()) {
+                errorMsg = response.getMessage();
+                errorType = "RESTORE_FAILED";
             }
 
             log.info("Estados originales restaurados para todos los dispositivos de la orden {}", order.getId());
 
         } catch (FeignException.ServiceUnavailable fe) {
+
+            // Si el microservicio devuelve un 503
             log.error("El servicio de dispositivos no está disponible para la orden {}: {}", order.getId(), fe.getMessage());
-            throw new DeviceUnavailableException(
-                    MessageException.SERVICE_UNAVAILABLE,
-                    DeviceUnavailableException.Type.SERVICE_UNAVAILABLE
-            );
+            errorMsg = fe.getMessage();
+            errorType = "SERVICE_UNAVAILABLE";
 
         } catch (FeignException.BadRequest fe) {
+
             log.error("Solicitud inválida al servicio de dispositivos para la orden {}: {}", order.getId(), fe.getMessage());
-            throw new DeviceUnavailableException(
-                    MessageException.INVALID_REQUEST,
-                    DeviceUnavailableException.Type.BAD_REQUEST
-            );
+            errorMsg = fe.getMessage();
+            errorType = "BAD_REQUEST";
 
         } catch (FeignException fe) {
+
             log.error("Error de comunicación con el servicio de dispositivos para la orden {}: {}", order.getId(), fe.getMessage());
-            throw new DeviceUnavailableException(
-                    MessageException.DEVICE_ERROR_COMMUNICATION,
-                    DeviceUnavailableException.Type.INTERNAL_SERVER
-            );
+            errorMsg = fe.getMessage();
+            errorType = "INTERNAL_SERVER";
+        }
+
+        if (errorMsg != null) {
+            OrderIntegrationErrorDto errorDto = OrderIntegrationErrorDto.builder()
+                    .service("devices")
+                    .type(errorType)
+                    .message("Error al restaurar dispositivos: " + errorMsg)
+                    .timestamp(java.time.Instant.now())
+                    .deviceIds(devicesIds)
+                    .build();
+            addErrorToOrderSnapshot(order, errorDto);
         }
     }
 
@@ -988,12 +1007,19 @@ public class OrderServiceImpl implements OrderService {
     }
 
     /**
-     * Actualiza los datos de una orden existente.
+     * Actualiza una orden existente, gestionando la reasignación de dispositivos.
+     *
+     * <p>Compara dispositivos actuales vs nuevos, restaura estados de removidos,
+     * verifica disponibilidad y reserva nuevos dispositivos. Publica evento de
+     * notificación si cambia el assignee.</p>
+     *
+     * <p><strong>Nota:</strong> Si falla la restauración de dispositivos, el error
+     * se registra en el snapshot y no se eliminan los items de la orden.</p>
      *
      * @param orderId UUID de la orden a actualizar
-     * @param rq datos actualizados de la orden
-     * @throws OrderException si la orden no existe (NOT_FOUND)
-     * @throws DeviceException si algún dispositivo no está disponible o no existe
+     * @param rq datos actualizados (assignee, dispositivos, descripción)
+     * @throws OrderException si la orden no existe o datos inválidos
+     * @throws DeviceException si algún dispositivo no está disponible
      */
     public void updateOrder(UUID orderId, OrderRq rq) {
 
@@ -1001,6 +1027,9 @@ public class OrderServiceImpl implements OrderService {
         Order order = orderRepository.findById(orderId).orElseThrow(
                 () -> new OrderException(MessageException.ORDER_NOT_FOUND, OrderException.Type.NOT_FOUND)
         );
+
+        // limpiar snapshot
+        order.setSnapshot(null);
 
         // Guardar valores originales para comparar
         AssigneeType originalAssigneeType = order.getAssigneeType();
@@ -1037,10 +1066,12 @@ public class OrderServiceImpl implements OrderService {
             RestoreDevicesRq restoreRequest = buildRestoreRequest(originalStatesToRestore);
 
             // Restaurar estados de dispositivos ANTES de eliminar los items
-            devicesClient.restoreDeviceStates(restoreRequest);
+            restoreDevices(restoreRequest, order);
 
-            // Eliminar OrderItems de la lista (orphanRemoval los borrará de BD)
-            order.getItems().removeIf(item -> devicesToRemove.contains(item.getDeviceId()));
+            // Eliminar OrderItems de la lista (orphanRemoval los borrará de BD) solo si el snapshot llega vacio
+            if (order.getSnapshot() == null) {
+                order.getItems().removeIf(item -> devicesToRemove.contains(item.getDeviceId()));
+            }
         }
 
         // Agregar nuevos dispositivos
@@ -1114,5 +1145,103 @@ public class OrderServiceImpl implements OrderService {
         return RestoreDevicesRq.builder()
                 .items(items)
                 .build();
+    }
+
+    /**
+     * Valida si una orden con errores está lista para cambiar a estado CREATED.
+     *
+     * Verifica que todos los campos requeridos estén completos:
+     * - Tiene al menos un dispositivo asignado
+     * - Tiene assignee (empleado o grupo) configurado
+     * - El estado actual es CREATED_WITH_ERRORS
+     *
+     * Si cumple todas las condiciones, cambia el estado a CREATED.
+     *
+     * @param order orden a validar
+     */
+    private void validateOrderState(Order order) {
+        // Solo aplicar si el estado actual es CREATED_WITH_ERRORS
+        if (!OrderState.CREATED_WITH_ERRORS.equals(order.getState())) {
+            return;
+        }
+
+        // Validar que tenga al menos un dispositivo
+        boolean hasDevices = order.getItems() != null && !order.getItems().isEmpty();
+
+        // Validar que tenga assignee configurado
+        boolean hasAssignee = order.getAssigneeType() != null && order.getAssigneeId() != null;
+
+        // Si cumple todas las condiciones, cambiar a CREATED
+        if (hasDevices && hasAssignee) {
+            order.setState(OrderState.CREATED);
+            log.info("Orden {} cambió de CREATED_WITH_ERRORS a CREATED tras completar datos", order.getId());
+        }
+    }
+
+    /**
+     * Restaura los estados originales de los dispositivos asociados a una orden.
+     *
+     * Realiza la llamada al microservicio de dispositivos para restaurar los estados
+     * originales de cada dispositivo. Si ocurre algún error durante la comunicación,
+     * registra el error en el snapshot de la orden para trazabilidad.
+     *
+     * @param restoreDevicesRq solicitud con los dispositivos y sus estados originales a restaurar
+     * @param order orden que contiene los dispositivos a restaurar
+     * @throws FeignException.ServiceUnavailable si el servicio de dispositivos no está disponible (503)
+     * @throws FeignException.BadRequest si la solicitud es inválida (400)
+     * @throws FeignException si ocurre otro error de comunicación con el servicio
+     */
+    private void restoreDevices(RestoreDevicesRq restoreDevicesRq, Order order) {
+
+        String errorMsg = null;
+        String errorType = null;
+
+        // Extraer solo los UUIDs desde restoreDevicesRq.getItems()
+        List<UUID> devicesIds = restoreDevicesRq.getItems().stream()
+                .map(RestoreDevicesRq.RestoreItem::getDeviceId)
+                .toList();
+
+        try {
+            // Llamar al cliente Feign para restaurar los dispositivos
+            ApiResponseDto<Void> response  = devicesClient.restoreDeviceStates(restoreDevicesRq);
+
+            // Verifica el éxito de la operación
+            if (!response.isSuccess()) {
+                errorMsg = response.getMessage();
+                errorType = "RESTORE_FAILED";
+            }
+
+            log.info("Estados originales restaurados para todos los dispositivos de la orden {}", order.getId());
+
+        } catch (FeignException.ServiceUnavailable fe) {
+
+            // Si el microservicio devuelve un 503
+            log.error("El servicio de dispositivos no está disponible para la orden {}: {}", order.getId(), fe.getMessage());
+            errorMsg = fe.getMessage();
+            errorType = "SERVICE_UNAVAILABLE";
+
+        } catch (FeignException.BadRequest fe) {
+
+            log.error("Solicitud inválida al servicio de dispositivos para la orden {}: {}", order.getId(), fe.getMessage());
+            errorMsg = fe.getMessage();
+            errorType = "BAD_REQUEST";
+
+        } catch (FeignException fe) {
+
+            log.error("Error de comunicación con el servicio de dispositivos para la orden {}: {}", order.getId(), fe.getMessage());
+            errorMsg = fe.getMessage();
+            errorType = "INTERNAL_SERVER";
+        }
+
+        if (errorMsg != null) {
+            OrderIntegrationErrorDto errorDto = OrderIntegrationErrorDto.builder()
+                    .service("devices")
+                    .type(errorType)
+                    .message("Error al restaurar dispositivos: " + errorMsg)
+                    .timestamp(java.time.Instant.now())
+                    .deviceIds(devicesIds)
+                    .build();
+            addErrorToOrderSnapshot(order, errorDto);
+        }
     }
 }

--- a/src/main/java/com/infragest/infra_orders_service/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/infragest/infra_orders_service/service/impl/OrderServiceImpl.java
@@ -22,6 +22,7 @@ import com.infragest.infra_orders_service.service.OrderService;
 import com.infragest.infra_orders_service.util.MessageException;
 import feign.FeignException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.HttpStatus;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -855,6 +856,33 @@ public class OrderServiceImpl implements OrderService {
                     String.format(MessageException.EQUIPMENT_RESTORE_FAILED, order.getId()),
                     OrderException.Type.INTERNAL_SERVER
             );
+        }
+    }
+
+    public void updateOrder(UUID orderId, OrderRq rq) {
+
+        // Recuperar la orden
+        Order order = orderRepository.findById(orderId).orElseThrow(
+                () -> new OrderException(MessageException.ORDER_NOT_FOUND, OrderException.Type.NOT_FOUND)
+        );
+
+        // Comparar los devicesIds de la orden nueva con la orden antigua y separa los que no coinciden
+        Set<UUID> currentDeviceIds = order.getItems().stream()
+                .map(OrderItem::getDeviceId)
+                .collect(Collectors.toSet());
+
+        Set<UUID> newDeviceIds = new HashSet<>(rq.getDevicesIds());
+
+        // Verificar dispositivos y obtener su estado original
+        Map<UUID, String> originalStates = verifyDevicesAndFetchState((List<UUID>) newDeviceIds);
+
+        // Validar si el tipo de asignación es diferente
+        if (order.getAssigneeType() != rq.getAssigneeType()) {
+            // Obtener los correos asociados a la asignación
+            List<String> recipients = resolveRecipientsAndValidate(rq.getAssigneeType(), rq.getAssigneeId());
+
+            // Publicar el evento
+            publishOrderEvent(savedOrder, recipients);
         }
     }
 }


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción
- Endpoint `PUT /orders/update/{orderId}` para actualizar órdenes existentes
- Gestión inteligente de dispositivos: restaura estados de removidos y reserva nuevos
- Validación de disponibilidad de dispositivos antes de asignar
- Notificación automática cuando cambia el assignee (empleado/grupo)
- Refactorización de `saveOrderAndItems()` para reutilización en creación y actualización
- Método auxiliar `buildRestoreRequest()` para conversión de datos a `RestoreDevicesRq`
- Documentación JavaDoc y OpenAPI/Swagger completa

## ¿Qué tipo de cambio es?
- [x] Bugfix 🐞
- [x] Feature ✨
- [x] Refactor 🔧
- [x] Documentación 📚
- [x] Otro

## ¿Cómo probar estos cambios?

- `POST /orders` → Crear orden con 2 dispositivos
- `PUT /orders/update/{id}` → Cambiar lista de dispositivos (agregar/quitar)
- `PUT /orders/update/{id}` → Cambiar assignee (probar notificación)
- `PUT /orders/update/invalid-id` → Verificar error 404 snapshot guardado
- `PUT /orders/update/{id}` con dispositivo ocupado → Verificar error 409 snapshot guardado


## Checklist
- [x] El código compila y pasa los tests
- [x] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
<!-- Adjunta capturas si hay cambios visuales. -->

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
<!-- Información extra útil para quien revisa el PR -->
